### PR TITLE
[FE] ルームに参加する選択肢のコンポーネントの作成

### DIFF
--- a/frontend/src/app/top/components/JoinRoomArea/index.stories.tsx
+++ b/frontend/src/app/top/components/JoinRoomArea/index.stories.tsx
@@ -1,0 +1,16 @@
+// JoinRoomArea.stories.ts|tsx
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { JoinRoomArea } from './index';
+
+const meta: Meta<typeof JoinRoomArea> = {
+  title: 'TopPage/JoinRoomArea',
+  component: JoinRoomArea,
+};
+
+export default meta;
+type Story = StoryObj<typeof JoinRoomArea>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/app/top/components/JoinRoomArea/index.tsx
+++ b/frontend/src/app/top/components/JoinRoomArea/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Box, Text, VStack } from '@chakra-ui/react';
+import { BiSolidRightArrow } from 'react-icons/bi';
+import { Avatar } from '@/app/top/components/Avatar';
+import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWithRightIcon';
+import { InputName } from '@/components/Input/Name';
+
+export function JoinRoomArea() {
+  return (
+    <Box maxW="50%" bgColor="#65DAFF" borderRadius="lg" py={8} px={28}>
+      <VStack spacing={6} textAlign="center">
+        <Text color="white" fontSize="2xl" fontWeight="bold">
+          自分のアバターを設定してください
+        </Text>
+        <Avatar />
+        <InputName borderColor="#56C1FC" />
+        <Box w="60%">
+          <OutlineButtonWithRightIcon
+            text="参加"
+            rightIcon={<BiSolidRightArrow />}
+            color="#56C1FC"
+            bgColor="white"
+          />
+        </Box>
+      </VStack>
+    </Box>
+  );
+}

--- a/frontend/src/app/top/page.tsx
+++ b/frontend/src/app/top/page.tsx
@@ -1,5 +1,5 @@
-import { Avatar } from '@/app/top/components/Avatar';
+import { JoinRoomArea } from '@/app/top/components/JoinRoomArea';
 
 export default function Top() {
-  return <Avatar />;
+  return <JoinRoomArea />;
 }

--- a/frontend/src/components/Button/OutlineButtonWithRightIcon/index.stories.tsx
+++ b/frontend/src/components/Button/OutlineButtonWithRightIcon/index.stories.tsx
@@ -1,0 +1,21 @@
+// OutlineButtonWithRightIcon.stories.ts|tsx
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { BiSolidRightArrow } from 'react-icons/bi';
+import { OutlineButtonWithRightIcon } from './index';
+
+const meta: Meta<typeof OutlineButtonWithRightIcon> = {
+  title: 'Button/OutlineWithRightIcon',
+  component: OutlineButtonWithRightIcon,
+};
+
+export default meta;
+type Story = StoryObj<typeof OutlineButtonWithRightIcon>;
+
+export const Default: Story = {
+  args: {
+    text: '参加する',
+    rightIcon: <BiSolidRightArrow />,
+    color: '#56C1FC',
+  },
+};

--- a/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
+++ b/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
@@ -1,0 +1,34 @@
+import { Button } from '@chakra-ui/react';
+import { ReactElement } from 'react';
+
+type Props = {
+  text: string;
+  rightIcon: ReactElement;
+  color: string;
+  bgColor: string;
+  borderWidth?: string;
+};
+
+export function OutlineButtonWithRightIcon({
+  text,
+  rightIcon,
+  color,
+  bgColor,
+  borderWidth = '3px',
+}: Props) {
+  return (
+    <Button
+      w="full"
+      size="lg"
+      rightIcon={rightIcon}
+      color={color}
+      borderWidth={borderWidth}
+      borderColor={color}
+      borderRadius="2xl"
+      variant="outline"
+      backgroundColor={bgColor}
+    >
+      {text}
+    </Button>
+  );
+}

--- a/frontend/src/components/Input/Name/index.stories.tsx
+++ b/frontend/src/components/Input/Name/index.stories.tsx
@@ -1,0 +1,18 @@
+// InputName.stories.ts|tsx
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { InputName } from './index';
+
+const meta: Meta<typeof InputName> = {
+  title: 'Input/InputName',
+  component: InputName,
+};
+
+export default meta;
+type Story = StoryObj<typeof InputName>;
+
+export const Default: Story = {
+  args: {
+    borderColor: '#56C1FC',
+  },
+};

--- a/frontend/src/components/Input/Name/index.tsx
+++ b/frontend/src/components/Input/Name/index.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { ChangeEventHandler } from 'react';
+import { Input } from '@chakra-ui/react';
+
+type Props = {
+  value?: string;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  borderColor: string;
+  placeholder?: string;
+};
+
+export function InputName({
+  value,
+  onChange,
+  borderColor,
+  placeholder = '名前を入力',
+}: Props) {
+  return (
+    <Input
+      size="lg"
+      variant="outline"
+      bgColor="white"
+      placeholder={placeholder}
+      borderColor={borderColor}
+      borderWidth="3px"
+      borderRadius="xl"
+      value={value}
+      onChange={onChange}
+    />
+  );
+}


### PR DESCRIPTION
## 🔨 変更内容

- ルームに参加する選択肢のコンポーネントの作成
- 共通するOutlineButtonのコンポーネントの作成
- 共通するInputのコンポーネントの作成

## 📸 スクリーンショット
<img width="1200" alt="スクリーンショット 2023-08-21 0 26 44" src="https://github.com/tornado-team4/tornado/assets/64648525/673327ef-d4e7-472b-a5ba-fb68a789dad7">

## ✅ 解決するイシュー

- close #15

## 🤝 関連するイシュー

- #13 
