### PR TITLE
[BE] 参加者のリストの応答周りの実装

### DIFF
--- a/backend/cruds/read/participant_list.py
+++ b/backend/cruds/read/participant_list.py
@@ -1,0 +1,16 @@
+def participant_list(db, id):
+    docs = db.collection("room").document(id).collection("users").stream()
+
+    res = []
+    # ドキュメントの値を表示
+    for doc in docs:
+        print(f"{doc.id} => {doc.to_dict()}")
+        res.append(
+            {
+                "id": doc.id,
+                "name": doc.to_dict().get("name"),
+                "avatar_url": doc.to_dict().get("avatar"),
+                "role": doc.to_dict().get("role"),
+            }
+        )
+    return res


### PR DESCRIPTION
## 🔨 変更内容

- Websocket を用いて、参加者のリストを応答するように実装
- 想定の使用法
  - 参加画面で参加をする (このとき DB には参加者が追加される) 
  -  ロビー画面に遷移し `ws://{domain}/ws/${id}` に接続
  - 接続された際に、それまでに接続しているコネクションに参加者のリスト (新しい参加者は追加済み) を返す
  - FE でそのリストを使用して、描画される参加者リストを更新

## 📸 スクリーンショット
![issue-31](https://github.com/tornado-team4/tornado/assets/68209431/62e08dff-982e-44b8-9c53-26f2cda0fd79)

## ✅ 解決するイシュー

- close #37

## 🤝 関連するイシュー

- #0
