### PR TITLE
[BE] upload されたファイルと room を紐付ける諸々の API の作成

### DIFF
--- a/backend/cruds/create/upload_image.py
+++ b/backend/cruds/create/upload_image.py
@@ -1,0 +1,6 @@
+def upload_image(db, room_id, file_name):
+    images_collection_ref = db.collection("room").document(room_id).collection("images")
+    images_doc_ref = images_collection_ref.document()
+    images_doc_ref.set({"file_name": file_name})
+
+    return "success"

--- a/backend/cruds/read/image_list.py
+++ b/backend/cruds/read/image_list.py
@@ -1,0 +1,7 @@
+def image_list(db, room_id):
+    docs = db.collection("room").document(room_id).collection("images").stream()
+    res = []
+    for doc in docs:
+        res.append(doc.to_dict().get("file_name"))
+
+    return res

--- a/backend/cruds/read/participant_list.py
+++ b/backend/cruds/read/participant_list.py
@@ -4,7 +4,6 @@ def participant_list(db, id):
     res = []
     # ドキュメントの値を表示
     for doc in docs:
-        print(f"{doc.id} => {doc.to_dict()}")
         res.append(
             {
                 "id": doc.id,

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,8 +7,10 @@ from firebase_admin import credentials, firestore
 import cruds.read.root as read_root
 import cruds.read.avatar_list as read_avatar_list
 import cruds.read.participant_list as read_participant_list
+import cruds.read.image_list as read_image_list
 import cruds.create.create_room as create_room
 import cruds.create.join_room as join_room
+import cruds.create.upload_image as upload_image
 import utils.convert_env_to_dict as convert_env_to_dict
 
 app = FastAPI()
@@ -68,6 +70,16 @@ def get_avatar_list():
     return res
 
 
+@app.get(
+    "/api/v1/images",
+    summary="room id に紐づく画像名の一覧を取得するエンドポイント",
+    description="room id に紐づく画像名の一覧を取得するエンドポイント",
+)
+def get_image_list(room_id: str):
+    res = read_image_list.image_list(db, room_id)
+    return res
+
+
 @app.post(
     "/api/v1/create-room",
     summary="ルームを作成するエンドポイント",
@@ -87,6 +99,16 @@ def post_create_room(name: str, avatar_url: str):
 )
 def post_join_room(room_id: str, name: str, avatar_url: str):
     res = join_room.join_room(db, room_id, name, avatar_url)
+    return res
+
+
+@app.post(
+    "/api/v1/upload-image",
+    summary="Storage に保存したファイル名を room id と紐付けるためのエンドポイント",
+    description="Storage に保存したファイル名を room id と紐付けるためのエンドポイント",
+)
+def post_upload_image(room_id: str, file_name: str):
+    res = upload_image.upload_image(db, room_id, file_name)
     return res
 
 


### PR DESCRIPTION
## 🔨 変更内容
### できるようになったこと
- FE から upload した画像のファイル名と room を紐付ける
  - いろんなパターンに耐えられるように1対多で設計 
- room に紐づいている画像の一覧を取得する

## 📸 スクリーンショット
### upload したファイル名と room を紐付ける API
![image](https://github.com/tornado-team4/tornado/assets/68209431/97696242-16f4-48ea-9ffa-9c71a41a77e4)

DB にも増えていることを確認
![image](https://github.com/tornado-team4/tornado/assets/68209431/fa50682e-7f28-4fc1-8358-70cd16ee09c9)

### room に紐づいているファイル名の一覧
![image](https://github.com/tornado-team4/tornado/assets/68209431/61e69f1e-673d-4501-82a0-8b42d007b11a)

## ✅ 解決するイシュー

- close #42
- close #43

## 🤝 関連するイシュー

- #40 
- #41
