### PR TITLE
[BE] ws でやりとりする内容にゲーム開始の概念を追加

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -113,6 +113,7 @@ def post_upload_image(room_id: str, file_name: str):
 
 
 # WebSocket用のエンドポイント
+# NOTE: 参加者の追加を検知して参加者のリストを返す & ゲームの開始を検知して、参加者にその旨を知らせる
 @app.websocket("/ws/{client_id}")
 async def websocket_endpoint(ws: WebSocket, client_id: str):
     await ws.accept()
@@ -126,11 +127,17 @@ async def websocket_endpoint(ws: WebSocket, client_id: str):
         connected_clients[client_id][key] = ws
 
     try:
-        # クライアントからのメッセージを待ち受け
         while True:
-            _ = await ws.receive_text()
+            # receive_test
+            # "connect"：ロビー画面をマウントする際に使用 -> 参加者のリストを返す
+            # "start"：ゲーム開始ボタンを押した場合に使用 -> ゲームの開始を知らせる
+            receive_text = await ws.receive_text()
 
-            res = read_participant_list.participant_list(db, client_id)
+            if receive_text == "connect":
+                res = read_participant_list.participant_list(db, client_id)
+            elif receive_text == "start":
+                res = "start"
+
             for client in connected_clients[client_id].values():
                 await client.send_json(res)
 


### PR DESCRIPTION
## 🔨 変更内容

- ロビー画面でホストがゲーム開始を押した場合に、その旨を参加者みんなに知らせるようにした

### 具体的な変更内容
- ws でやり取りするメッセージに、参加者のリストを返す場合と、ゲーム開始の場合を分けるようにした

## 📸 スクリーンショット
FE の UI は動作確認ように作成しただけであるため、差分には含めていない (参照：[times-sugimizu](https://discordapp.com/channels/1135854997792362526/1136170435902451803/1143559295896653824) )

![issue-48](https://github.com/tornado-team4/tornado/assets/68209431/6de4c4fc-d549-4347-b0f0-3c1c697020fa)

## ✅ 解決するイシュー

- close #48 

## 🤝 関連するイシュー

- #18