### PR TITLE
[BE] 部屋に紐づくコメントの一覧を取得するための API の作成

### DIFF
--- a/backend/cruds/read/comment_list.py
+++ b/backend/cruds/read/comment_list.py
@@ -1,0 +1,16 @@
+def comment_list(db, id):
+    docs = db.collection("room").document(id).collection("comments").stream()
+
+    res = []
+    # ドキュメントの値を表示
+    for doc in docs:
+        res.append(
+            {
+                "id": doc.id,  # 自動採番される id
+                "gameProgress": doc.to_dict().get("gameProgress"),
+                "text": doc.to_dict().get("text"),
+                "user_id": doc.to_dict().get("userId"),
+                "user_name": doc.to_dict().get("userName"),
+            }
+        )
+    return res

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,10 +9,12 @@ import cruds.read.root as read_root
 import cruds.read.avatar_list as read_avatar_list
 import cruds.read.participant_list as read_participant_list
 import cruds.read.image_list as read_image_list
+import cruds.read.comment_list as read_comment_list
 import cruds.create.create_room as create_room
 import cruds.create.join_room as join_room
 import cruds.create.upload_image as upload_image
 import utils.convert_env_to_dict as convert_env_to_dict
+import utils.selection_album_comments as selection_album_comments
 
 app = FastAPI()
 
@@ -43,6 +45,7 @@ db = firestore.client()
 # WebSocket接続を管理するための dict
 connected_clients = {}
 
+
 # --------------------
 
 # Pydanticのデータモデル
@@ -52,6 +55,7 @@ connected_clients = {}
 class RoomParams(BaseModel):
     name: str
     avatar_url: str
+
 
 # --------------------
 
@@ -88,6 +92,23 @@ def get_avatar_list():
 def get_image_list(room_id: str):
     res = read_image_list.image_list(db, room_id)
     return res
+
+
+@app.get(
+    "/api/v1/comment-list",
+    summary="コメント一覧を取得するエンドポイント",
+    description="コメント一覧を取得するエンドポイント",
+)
+def get_comment_list(room_id: str):
+    fetch_data = read_comment_list.comment_list(db, room_id)
+
+    # 取得したデータを元にアルバムに使用するコメントを抽出
+    albumComments = selection_album_comments.selection_album_comments(fetch_data)
+
+    return {
+        "allComments": fetch_data,
+        "albumComments": albumComments,
+    }
 
 
 @app.post(

--- a/backend/utils/selection_album_comments.py
+++ b/backend/utils/selection_album_comments.py
@@ -1,0 +1,10 @@
+def selection_album_comments(original_data: list):
+    # 参加人数は6人, gameProgress は1(アルバムに使用する画像は1枚)のミニマムな実装をしている
+    # userId の重複する人がいる場合1ユーザー1コメントにする
+    s = set()
+    res = []
+    for data in original_data:
+        if data["user_id"] not in s:
+            res.append(data)
+            s.add(data["user_id"])
+    return res


### PR DESCRIPTION
## 🔨 変更内容

- 部屋に紐づくコメントの一覧を取得するための API の作成
- response に含む内容
  - コメントの一覧
  - アルバムに使用するコメントの一覧
- 参加人数6人, 写真1枚を想定する場合、アルバム用にコメントを抽出する必要は特にないが、一応コメントの一覧で `user_id` の重複をチェックし、1つの `user_id` に対して、1つのコメントを返すようにした

## 📸 スクリーンショット
デプロイ環境で適切なレスポンスが返ってくることを確認
![image](https://github.com/tornado-team4/tornado/assets/68209431/0d70a68e-7eee-4a3a-8e29-3b3084ab9f21)

## ✅ 解決するイシュー

- close #54

## 🤝 関連するイシュー

- #32 
- #34
