### PR TITLE
[FE] ルーム参加の概念の追加

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from starlette.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from typing import Union
 
 import firebase_admin
 from firebase_admin import credentials, firestore
@@ -55,6 +56,7 @@ connected_clients = {}
 class RoomParams(BaseModel):
     name: str
     avatar_url: str
+    room_id: Union[str, None] = None
 
 
 # --------------------
@@ -130,7 +132,10 @@ def post_create_room(params: RoomParams):
     description="ルームに参加するエンドポイント",
     response_description="ルームのIDとユーザーのID",
 )
-def post_join_room(room_id: str, name: str, avatar_url: str):
+def post_join_room(params: RoomParams):
+    room_id = params.room_id
+    name = params.name
+    avatar_url = params.avatar_url
     res = join_room.join_room(db, room_id, name, avatar_url)
     return res
 

--- a/frontend/src/app/top/[id]/page.tsx
+++ b/frontend/src/app/top/[id]/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { TopPage } from '../components/TopPage';
+
+export default function TopId() {
+  const pathname = usePathname();
+  const roomId = pathname.replace('/top/', '');
+
+  return <TopPage roomId={roomId} />;
+}

--- a/frontend/src/app/top/components/JoinRoomArea/index.tsx
+++ b/frontend/src/app/top/components/JoinRoomArea/index.tsx
@@ -43,6 +43,7 @@ export function JoinRoomArea({ roomId }: Props) {
             rightIcon={<BiSolidRightArrow />}
             color="#56C1FC"
             bgColor="white"
+            isDisabled={name === ''}
             onClick={handleJoinRoom}
           />
         </Box>

--- a/frontend/src/app/top/components/JoinRoomArea/index.tsx
+++ b/frontend/src/app/top/components/JoinRoomArea/index.tsx
@@ -7,8 +7,23 @@ import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWit
 import { InputName } from '@/components/Input/Name';
 import { useJoinRoomArea } from '../hooks/useJoinRoomArea';
 
-export function JoinRoomArea() {
-  const { name, setName, onSubmitHandler } = useJoinRoomArea();
+type Props = {
+  roomId: string;
+};
+
+export function JoinRoomArea({ roomId }: Props) {
+  const { name, setName, onCreateRoomHandler, onJoinRoomHandler } =
+    useJoinRoomArea();
+
+  const handleJoinRoom = async () => {
+    if (roomId === '') {
+      await onCreateRoomHandler();
+    } else {
+      await onJoinRoomHandler(roomId);
+    }
+
+    // ここに非同期処理が完了した後の状態更新などを追加
+  };
 
   return (
     <Box w="full" bgColor="#65DAFF" borderRadius="lg" py={8} px={28}>
@@ -28,7 +43,7 @@ export function JoinRoomArea() {
             rightIcon={<BiSolidRightArrow />}
             color="#56C1FC"
             bgColor="white"
-            onClick={onSubmitHandler}
+            onClick={handleJoinRoom}
           />
         </Box>
       </VStack>

--- a/frontend/src/app/top/components/TopPage/index.tsx
+++ b/frontend/src/app/top/components/TopPage/index.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { Stack, Box, VStack, Image } from '@chakra-ui/react';
+import { JoinRoomArea } from '@/app/top/components/JoinRoomArea';
+import { HowToPlayArea } from '@/app/top/components/HowToPlayArea';
+import logo from '/public/logo.png';
+import bg_img from '/public/bg_img.jpeg';
+
+type Props = {
+  roomId: string; // 空文字列の場合「ルームの作成」
+};
+
+export function TopPage({ roomId }: Props) {
+  return (
+    <Box
+      w="full"
+      h="full"
+      minH="100vh"
+      bgImage={bg_img.src}
+      objectFit="cover"
+      p={8}
+    >
+      <Box
+        w="full"
+        h="full"
+        minH="100vh"
+        bg="whiteAlpha.500"
+        borderRadius={10}
+        py={10}
+        px={4}
+      >
+        <VStack h="full" w="full">
+          <Image src={logo.src} alt="青春パズルロゴ" />
+          <Box h={{ base: 14, md: 20 }} />
+          <Stack
+            direction={{ base: 'column', md: 'row' }}
+            w="full"
+            justifyContent="center"
+          >
+            <Box w={{ base: 'full', md: '50%' }}>
+              <JoinRoomArea roomId={roomId} />
+            </Box>
+            <Box w={{ base: 'full', md: '50%' }}>
+              <HowToPlayArea />
+            </Box>
+          </Stack>
+        </VStack>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/app/top/components/hooks/useJoinRoomArea.ts
+++ b/frontend/src/app/top/components/hooks/useJoinRoomArea.ts
@@ -23,7 +23,7 @@ export const useJoinRoomArea = () => {
   // リストの最初の値を初期に表示されるavatarとする
   const initialAvatar = avatarList ? avatarList[0] : '';
 
-  const onSubmitHandler = async () => {
+  const onCreateRoomHandler = async () => {
     const avatarUrl = avatar ? avatar : initialAvatar;
 
     await fetch(
@@ -50,6 +50,33 @@ export const useJoinRoomArea = () => {
       );
   };
 
+  const onJoinRoomHandler = async (roomId: string) => {
+    const avatarUrl = avatar ? avatar : initialAvatar;
+
+    await fetch(
+      `
+    ${BASE_URL}/api/v1/create-room
+    `,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name, avatar_url: avatarUrl, room_id: roomId }),
+      },
+    )
+      .then(() => router.replace('/'))
+      .catch(() =>
+        toast({
+          title: '通信に失敗しました。',
+          description:
+            '申し訳ありませんが、時間をおいてもう一度お試しください。',
+          status: 'error',
+          isClosable: true,
+        }),
+      );
+  };
+
   return {
     avatarList,
     avatarListError: error,
@@ -58,6 +85,7 @@ export const useJoinRoomArea = () => {
     setAvatar,
     name,
     setName,
-    onSubmitHandler,
+    onCreateRoomHandler,
+    onJoinRoomHandler,
   };
 };

--- a/frontend/src/app/top/components/hooks/useJoinRoomArea.ts
+++ b/frontend/src/app/top/components/hooks/useJoinRoomArea.ts
@@ -55,7 +55,7 @@ export const useJoinRoomArea = () => {
 
     await fetch(
       `
-    ${BASE_URL}/api/v1/create-room
+    ${BASE_URL}/api/v1/join-room
     `,
       {
         method: 'POST',

--- a/frontend/src/app/top/page.tsx
+++ b/frontend/src/app/top/page.tsx
@@ -1,47 +1,7 @@
 'use client';
 
-import { Stack, Box, VStack, Image } from '@chakra-ui/react';
-import { JoinRoomArea } from '@/app/top/components/JoinRoomArea';
-import { HowToPlayArea } from '@/app/top/components/HowToPlayArea';
-import logo from '/public/logo.png';
-import bg_img from '/public/bg_img.jpeg';
+import { TopPage } from './components/TopPage';
 
 export default function Top() {
-  return (
-    <Box
-      w="full"
-      h="full"
-      minH="100vh"
-      bgImage={bg_img.src}
-      objectFit="cover"
-      p={8}
-    >
-      <Box
-        w="full"
-        h="full"
-        minH="100vh"
-        bg="whiteAlpha.500"
-        borderRadius={10}
-        py={10}
-        px={4}
-      >
-        <VStack h="full" w="full">
-          <Image src={logo.src} alt="青春パズルロゴ" />
-          <Box h={{ base: 14, md: 20 }} />
-          <Stack
-            direction={{ base: 'column', md: 'row' }}
-            w="full"
-            justifyContent="center"
-          >
-            <Box w={{ base: 'full', md: '50%' }}>
-              <JoinRoomArea />
-            </Box>
-            <Box w={{ base: 'full', md: '50%' }}>
-              <HowToPlayArea />
-            </Box>
-          </Stack>
-        </VStack>
-      </Box>
-    </Box>
-  );
+  return <TopPage roomId="" />;
 }

--- a/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
+++ b/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
@@ -7,6 +7,7 @@ type Props = {
   color: string;
   bgColor: string;
   borderWidth?: string;
+  isDisabled: boolean;
   onClick?: () => void;
 };
 
@@ -16,6 +17,7 @@ export function OutlineButtonWithRightIcon({
   color,
   bgColor,
   borderWidth = '3px',
+  isDisabled,
   onClick,
 }: Props) {
   return (
@@ -29,6 +31,7 @@ export function OutlineButtonWithRightIcon({
       borderRadius="2xl"
       variant="outline"
       backgroundColor={bgColor}
+      isDisabled={isDisabled}
       onClick={onClick}
     >
       {text}


### PR DESCRIPTION
## 🔨 変更内容

- 「ルーム作成」の概念の追加
  - 仕様 
    - ルームを作成する場合 -> `{domain}/top` 
    - ルームに参加する場合 -> `{domain}/top/{room_id}` 


## 📸 スクリーンショット
### `/top` でルームの作成ができる (これまで通り)
リンクにアクセス
![image](https://github.com/tornado-team4/tornado/assets/68209431/9787f955-e51c-49e8-b536-dc6001318ba0)

正常に作成できていることを確認
![image](https://github.com/tornado-team4/tornado/assets/68209431/d9470500-a1ab-4fc9-9470-af1a71388bc3)

DB にも追加されていることを確認
![image](https://github.com/tornado-team4/tornado/assets/68209431/99eee453-ad8b-4304-b1bd-976fabdc5dc3)

### `/top/{room_id}` でルームへ参加ができる (✨追加部分)
さっき作成した `room_id` を含むリンクにアクセス
![image](https://github.com/tornado-team4/tornado/assets/68209431/95ba526f-7fba-42c8-a9b4-9a69305fd068)

正常に参加できていることを確認
と思ったけど、この PR で API を変更したから、今のデプロイ環境だとうまくいかないため、この PR を Merge した後確認する (BE のリンクはこのブランチで新しく発行されているリンクを参照できないため)

## ✅ 解決するイシュー

- close #53

## 🤝 関連するイシュー

- #0
