### PR TITLE
[FE]ロビー画面の画像アップロードのコンポーネント作成 

### DIFF
--- a/frontend/src/app/lobby/components/PuzzleMaker/index.stories.tsx
+++ b/frontend/src/app/lobby/components/PuzzleMaker/index.stories.tsx
@@ -1,0 +1,16 @@
+// PuzzleMaker.stories.ts|tsx
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { PuzzleMaker } from './index';
+
+const meta: Meta<typeof PuzzleMaker> = {
+  title: 'LobbyPage/PuzzleMaker',
+  component: PuzzleMaker,
+};
+
+export default meta;
+type Story = StoryObj<typeof PuzzleMaker>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/frontend/src/app/lobby/components/PuzzleMaker/index.tsx
+++ b/frontend/src/app/lobby/components/PuzzleMaker/index.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { InputImage } from '@/components/Input/Image';
+import { Box, VStack, Text } from '@chakra-ui/react';
+import { ChangeEvent, useState } from 'react';
+
+export const PuzzleMaker = () => {
+  const [image, setImage] = useState<File | null>(null); // eslint-disable-line @typescript-eslint/no-unused-vars
+  const [previewImageUrl, setPreviewImageUrl] = useState('');
+
+  const handleImage = (event: ChangeEvent<HTMLInputElement>) => {
+    if (!event.target.files) return;
+
+    const uploadedImage = event.target.files.item(0);
+    if (!uploadedImage) return;
+    const url = URL.createObjectURL(uploadedImage);
+    setPreviewImageUrl(url);
+    setImage(uploadedImage);
+  };
+
+  return (
+    <Box w="full" borderRadius={10} py={8} px={28} bg="rgba(101,218,255,0.5)">
+      <VStack spacing={6} textAlign="center">
+        <Text
+          color="white"
+          fontSize={{ base: 'xl', sm: '2xl' }}
+          fontWeight="bold"
+        >
+          パズル作成
+        </Text>
+        <InputImage
+          id={'puzzle'}
+          label="新規パズル作成"
+          src={previewImageUrl}
+          onChangeImage={handleImage}
+        />
+      </VStack>
+    </Box>
+  );
+};

--- a/frontend/src/components/Input/Image/index.stories.tsx
+++ b/frontend/src/components/Input/Image/index.stories.tsx
@@ -1,0 +1,18 @@
+// InputImage.stories.ts|tsx
+
+import type { Meta, StoryObj } from '@storybook/react';
+import { InputImage } from './index';
+
+const meta: Meta<typeof InputImage> = {
+  title: 'Input/InputImage',
+  component: InputImage,
+};
+
+export default meta;
+type Story = StoryObj<typeof InputImage>;
+
+export const Default: Story = {
+  args: {
+    label: '新規パズル作成',
+  },
+};

--- a/frontend/src/components/Input/Image/index.tsx
+++ b/frontend/src/components/Input/Image/index.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import type { ChangeEventHandler } from 'react';
+import { useState } from 'react';
+import {
+  Center,
+  FormLabel,
+  ImageProps,
+  Input,
+  Skeleton,
+  Image,
+  Icon,
+  HStack,
+  Text,
+} from '@chakra-ui/react';
+import { GrAdd } from 'react-icons/gr';
+
+type Props = {
+  id: string;
+  onChangeImage: ChangeEventHandler<HTMLInputElement>;
+  label?: string;
+};
+
+export const InputImage = ({
+  id,
+  onChangeImage,
+  label,
+  ...props
+}: Props & ImageProps) => {
+  const [isLoaded, setIsLoaded] = useState(!props.src);
+
+  const onLoad = () => {
+    setIsLoaded(true);
+  };
+
+  return (
+    <Center>
+      <FormLabel htmlFor={id} cursor="pointer" m="0">
+        <Skeleton isLoaded={isLoaded} width="fit-content">
+          <Image
+            w="full"
+            h="full"
+            minH={80}
+            minW={80}
+            maxH={96}
+            maxW={96}
+            alt={props.alt}
+            onLoad={onLoad}
+            onError={onLoad}
+            objectFit="cover"
+            fallback={
+              <Center
+                w="full"
+                h="full"
+                minW={80}
+                minH={80}
+                bg="white"
+                p={10}
+                border={'1px solid'}
+              >
+                <HStack>
+                  <Text>{label}</Text>
+                  <Icon as={GrAdd} />
+                </HStack>
+              </Center>
+            }
+            {...props}
+          />
+        </Skeleton>
+        <Input
+          id={id}
+          type="file"
+          display="none"
+          accept="image/*"
+          onChange={onChangeImage}
+        />
+      </FormLabel>
+    </Center>
+  );
+};


### PR DESCRIPTION
## 🔨 変更内容

- 画像をアップロードできるInputImageコンポーネントの作成
- ロビー画面の右のエリアのパズル作成のコンポーネントの作成

## このPR外のタスク
- firebaseとの画像アップロード処理

## 📸 スクリーンショット
- UI
https://www.chromatic.com/test?appId=64db52dfe3cf0f4661d0edc7&id=64ee290756fe40ba51da2b82

- Storybook
https://64db52dfe3cf0f4661d0edc7-blqwmblurz.chromatic.com/?path=/story/lobbypage-puzzlemaker--default
## ✅ 解決するイシュー

- close #65 

## 🤝 関連するイシュー

- #18 
