### PR TITLE
[BE] 完成したパズルの画像の URL を取得する API の作成

### DIFF
--- a/backend/cruds/read/complete_image_url.py
+++ b/backend/cruds/read/complete_image_url.py
@@ -1,0 +1,3 @@
+def complete_image_url(db, room_id: str):
+    res = db.collection("room").document(room_id).collection("gameObjects").document("Image").get().to_dict().get("url")
+    return res

--- a/backend/main.py
+++ b/backend/main.py
@@ -11,6 +11,7 @@ import cruds.read.avatar_list as read_avatar_list
 import cruds.read.participant_list as read_participant_list
 import cruds.read.image_list as read_image_list
 import cruds.read.comment_list as read_comment_list
+import cruds.read.complete_image_url as read_complete_image_url
 import cruds.create.create_room as create_room
 import cruds.create.join_room as join_room
 import cruds.create.upload_image as upload_image
@@ -111,6 +112,16 @@ def get_comment_list(room_id: str):
         "allComments": fetch_data,
         "albumComments": albumComments,
     }
+
+
+@app.get(
+    "/api/v1/complete-image-url",
+    summary="そのゲームで完成したパズルの画像のURLを取得するエンドポイント",
+    description="そのゲームで完成したパズルの画像のURLを取得するエンドポイント",
+)
+def get_complete_image_url(room_id: str):
+    res = read_complete_image_url.complete_image_url(db, room_id)
+    return res
 
 
 @app.post(


### PR DESCRIPTION
## 🔨 変更内容

- {room_id} ドキュメントに、`gameObjects` コレクション, `Image` ドキュメント, `url: stinrg` フィールドの追加
  - 拡張の使用イメージ
    - 1つの画像のパズルをすることを1ゲームとした時に、1ゲームに使用する情報を `gameObjects` コレクションに格納する
      -  例えば1つのパズルが完成し、違う画像のパズルを行う場合は、`gameObject/Image/url` の値を更新する

![image](https://github.com/tornado-team4/tornado/assets/68209431/a4c5e69c-3fb1-4501-91e1-044f690d1529)
   

## 📸 スクリーンショット
デプロイ環境で、エンドポイントから正常な値が返ってくることを確認
![Uploading image.png…]()


## ✅ 解決するイシュー

- close #68

## 🤝 関連するイシュー

- #0
