### PR TITLE
[FE]ロビー画面のページの組み立てとBEとの繋ぎこみ

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -65,6 +65,7 @@ class FileParams(BaseModel):
     url: str
 
 
+
 # --------------------
 
 # エンドポイント

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ httpx
 firebase_admin
 google-cloud-firestore
 python-dotenv
+websockets

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@types/react": "18.2.18",
     "@types/react-dom": "18.2.7",
     "axios": "^1.5.0",
+    "encoding": "^0.1.13",
     "eslint": "8.46.0",
     "eslint-config-next": "13.4.13",
     "firebase": "^10.3.0",

--- a/frontend/src/app/lobby/components/LobbyPage/index.tsx
+++ b/frontend/src/app/lobby/components/LobbyPage/index.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { VSpacer } from '@/components/Spacer';
+import { Box, VStack, Image, Stack, HStack } from '@chakra-ui/react';
+import { LinkIcon } from '@chakra-ui/icons';
+import { BiSolidRightArrow } from 'react-icons/bi';
+import bg_img from 'public/bg_img.jpeg';
+import logo from 'public/logo.png';
+import { PlayerList } from '@/app/lobby/components/PlayerList';
+import { PuzzleMaker } from '@/app/lobby/components/PuzzleMaker';
+import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWithRightIcon';
+
+export const LobbyPage = () => {
+  return (
+    <Box
+      w="full"
+      h="full"
+      minH="100vh"
+      bgImage={bg_img.src}
+      objectFit="cover"
+      p={8}
+    >
+      <Box
+        w="full"
+        h="full"
+        minH="100vh"
+        bg="whiteAlpha.500"
+        borderRadius={10}
+        py={10}
+        px={4}
+      >
+        <VStack h="full" w="full">
+          <Image src={logo.src} alt="青春パズルロゴ" />
+          <VSpacer size={12} />
+          <Stack direction={{ base: 'column', md: 'row' }} w="full">
+            <Box w={{ base: 'full', md: '50%' }}>
+              <PlayerList list={[]} />
+            </Box>
+            <Box w={{ base: 'full', md: '50%' }}>
+              <VStack h="full" w="full">
+                <PuzzleMaker />
+                <VSpacer size={8} />
+                <HStack w="full">
+                  <OutlineButtonWithRightIcon
+                    height="70px"
+                    text={'招待する'}
+                    rightIcon={<LinkIcon />}
+                    color={'#56C1FC'}
+                    bgColor={'white'}
+                    isDisabled={false}
+                  />
+                  <OutlineButtonWithRightIcon
+                    height="70px"
+                    text={'開始'}
+                    rightIcon={<BiSolidRightArrow />}
+                    color={'#56C1FC'}
+                    bgColor={'white'}
+                    isDisabled={false}
+                  />
+                </HStack>
+              </VStack>
+            </Box>
+          </Stack>
+        </VStack>
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/src/app/lobby/components/LobbyPage/index.tsx
+++ b/frontend/src/app/lobby/components/LobbyPage/index.tsx
@@ -9,8 +9,13 @@ import logo from 'public/logo.png';
 import { PlayerList } from '@/app/lobby/components/PlayerList';
 import { PuzzleMaker } from '@/app/lobby/components/PuzzleMaker';
 import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWithRightIcon';
+import { useLobbyPage } from '@/app/lobby/hooks/useLobbyPage';
 
 export const LobbyPage = () => {
+  // 一旦roomIDを直で記載
+  const roomId = 'TBOvYdRCOpVK3aW3qMLp';
+  const { players } = useLobbyPage({ roomId: roomId });
+
   return (
     <Box
       w="full"
@@ -34,7 +39,7 @@ export const LobbyPage = () => {
           <VSpacer size={12} />
           <Stack direction={{ base: 'column', md: 'row' }} w="full">
             <Box w={{ base: 'full', md: '50%' }}>
-              <PlayerList list={[]} />
+              <PlayerList list={players} />
             </Box>
             <Box w={{ base: 'full', md: '50%' }}>
               <VStack h="full" w="full">

--- a/frontend/src/app/lobby/components/LobbyPage/index.tsx
+++ b/frontend/src/app/lobby/components/LobbyPage/index.tsx
@@ -14,7 +14,7 @@ import { useLobbyPage } from '@/app/lobby/hooks/useLobbyPage';
 export const LobbyPage = () => {
   // 一旦roomIDを直で記載
   const roomId = 'TBOvYdRCOpVK3aW3qMLp';
-  const { players, setImage, handleStart, isLoading } = useLobbyPage({
+  const { players, setImage, handleStart, isLoading, copylink } = useLobbyPage({
     roomId: roomId,
   });
 
@@ -55,6 +55,7 @@ export const LobbyPage = () => {
                     color={'#56C1FC'}
                     bgColor={'white'}
                     isDisabled={false}
+                    onClick={copylink}
                   />
                   <OutlineButtonWithRightIcon
                     height="70px"

--- a/frontend/src/app/lobby/components/LobbyPage/index.tsx
+++ b/frontend/src/app/lobby/components/LobbyPage/index.tsx
@@ -14,7 +14,9 @@ import { useLobbyPage } from '@/app/lobby/hooks/useLobbyPage';
 export const LobbyPage = () => {
   // 一旦roomIDを直で記載
   const roomId = 'TBOvYdRCOpVK3aW3qMLp';
-  const { players } = useLobbyPage({ roomId: roomId });
+  const { players, setImage, handleStart, isLoading } = useLobbyPage({
+    roomId: roomId,
+  });
 
   return (
     <Box
@@ -43,7 +45,7 @@ export const LobbyPage = () => {
             </Box>
             <Box w={{ base: 'full', md: '50%' }}>
               <VStack h="full" w="full">
-                <PuzzleMaker />
+                <PuzzleMaker setImage={setImage} />
                 <VSpacer size={8} />
                 <HStack w="full">
                   <OutlineButtonWithRightIcon
@@ -61,6 +63,8 @@ export const LobbyPage = () => {
                     color={'#56C1FC'}
                     bgColor={'white'}
                     isDisabled={false}
+                    isLoading={isLoading}
+                    onClick={handleStart}
                   />
                 </HStack>
               </VStack>

--- a/frontend/src/app/lobby/components/LobbyPage/index.tsx
+++ b/frontend/src/app/lobby/components/LobbyPage/index.tsx
@@ -10,13 +10,17 @@ import { PlayerList } from '@/app/lobby/components/PlayerList';
 import { PuzzleMaker } from '@/app/lobby/components/PuzzleMaker';
 import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWithRightIcon';
 import { useLobbyPage } from '@/app/lobby/hooks/useLobbyPage';
+import { useRecoilValue } from 'recoil';
+import { userState } from '@/store/userState';
 
 export const LobbyPage = () => {
   // 一旦roomIDを直で記載
-  const roomId = 'TBOvYdRCOpVK3aW3qMLp';
+  // const roomId = 'TBOvYdRCOpVK3aW3qMLp';
+  const roomId = useRecoilValue(userState).roomId;
   const { players, setImage, handleStart, isLoading, copylink } = useLobbyPage({
     roomId: roomId,
   });
+  if (roomId === '') return <>不正なアクセス</>;
 
   return (
     <Box

--- a/frontend/src/app/lobby/components/LobbyPage/index.tsx
+++ b/frontend/src/app/lobby/components/LobbyPage/index.tsx
@@ -20,6 +20,7 @@ export const LobbyPage = () => {
   const { players, setImage, handleStart, isLoading, copylink } = useLobbyPage({
     roomId: roomId,
   });
+
   if (roomId === '') return <>不正なアクセス</>;
 
   return (

--- a/frontend/src/app/lobby/components/PlayerList/index.tsx
+++ b/frontend/src/app/lobby/components/PlayerList/index.tsx
@@ -38,7 +38,7 @@ export const PlayerList = ({ list }: Props) => {
           <VStack spacing={3} w="full">
             {list.length > 0 ? (
               list.map((user) => (
-                <Card key={user.id} bg="white" w="full">
+                <Card key={user.name} bg="white" w="full">
                   <CardBody>
                     <HStack spacing={4}>
                       <Avatar size="md" src={user.avatarUrl} />

--- a/frontend/src/app/lobby/components/PlayerList/index.tsx
+++ b/frontend/src/app/lobby/components/PlayerList/index.tsx
@@ -30,16 +30,22 @@ export const PlayerList = ({ list }: Props) => {
         </Text>
         <Box w="full" h="lg" overflow="scroll">
           <VStack spacing={3} w="full">
-            {list.map((user) => (
-              <Card key={user.id} bg="white" w="full">
-                <CardBody>
-                  <HStack spacing={4}>
-                    <Avatar size="md" src={user.avatarUrl} />
-                    <Text>{user.name}</Text>
-                  </HStack>
-                </CardBody>
-              </Card>
-            ))}
+            {list.length > 0 ? (
+              list.map((user) => (
+                <Card key={user.id} bg="white" w="full">
+                  <CardBody>
+                    <HStack spacing={4}>
+                      <Avatar size="md" src={user.avatarUrl} />
+                      <Text>{user.name}</Text>
+                    </HStack>
+                  </CardBody>
+                </Card>
+              ))
+            ) : (
+              <Text fontSize="2xl" fontWeight="bold" color="white">
+                参加者がいません
+              </Text>
+            )}
           </VStack>
         </Box>
       </VStack>

--- a/frontend/src/app/lobby/components/PlayerList/index.tsx
+++ b/frontend/src/app/lobby/components/PlayerList/index.tsx
@@ -19,7 +19,13 @@ export const PlayerList = ({ list }: Props) => {
   const playerNum = list.length;
 
   return (
-    <Box w="full" borderRadius={10} py={8} px={28} bg="rgba(101,218,255,0.5)">
+    <Box
+      w="full"
+      borderRadius={10}
+      py={8}
+      px={{ base: 10, sm: 12 }}
+      bg="rgba(101,218,255,0.5)"
+    >
       <VStack spacing={6} textAlign="center">
         <Text
           color="white"

--- a/frontend/src/app/lobby/components/PuzzleMaker/index.tsx
+++ b/frontend/src/app/lobby/components/PuzzleMaker/index.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { useState } from 'react';
+import type { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import { InputImage } from '@/components/Input/Image';
 import { Box, VStack, Text } from '@chakra-ui/react';
-import { ChangeEvent, useState } from 'react';
 
-export const PuzzleMaker = () => {
-  const [image, setImage] = useState<File | null>(null); // eslint-disable-line @typescript-eslint/no-unused-vars
+type Props = {
+  setImage: Dispatch<SetStateAction<File | null>>;
+};
+
+export const PuzzleMaker = ({ setImage }: Props) => {
   const [previewImageUrl, setPreviewImageUrl] = useState('');
 
   const handleImage = (event: ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -1,0 +1,48 @@
+import { User } from '@/types/User';
+import { useState, useEffect } from 'react';
+
+type Props = {
+  roomId: string;
+};
+
+export const useLobbyPage = ({ roomId }: Props) => {
+  const [players, setPlayers] = useState<User[]>([]);
+  const id = roomId;
+  const domain = new URL(process.env.NEXT_PUBLIC_BACKEND_URL ?? '');
+  const host = domain.host;
+  const url = `ws://${host}/ws/${id}`;
+  const ws = new WebSocket(url);
+
+  useEffect(() => {
+    ws.onopen = () => {
+      // 参加者の通知を検知してリストを更新する際のwsメッセージ
+      ws.send('connect');
+    };
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+
+      if (typeof data === 'string' && data === 'start') {
+        console.log('ゲームの開始を検知');
+      } else {
+        const participantList: User[] = [];
+        data.map((d) =>
+          participantList.push({
+            id: d.id,
+            name: d.name,
+            avatarUrl: d.avatar_url,
+            role: d.role,
+          }),
+        );
+        setPlayers(participantList);
+      }
+    };
+    ws.onclose = () => {};
+    // コンポーネントがアンマウントされたらWebSocket接続をクローズ
+    return () => {
+      ws.close();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { players };
+};

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -13,6 +13,7 @@ import {
   updateDoc,
 } from 'firebase/firestore';
 import { db } from '@/libs/firebase/firebase';
+import { fetchImageUrl } from '@/libs/firebase/fetchImageUrl';
 
 type GameObjects = {
   Image: string;
@@ -94,7 +95,13 @@ export const useLobbyPage = ({ roomId }: Props) => {
           state: 'playing',
         });
       });
-      uploadImage(image);
+      const res = await uploadImage(image);
+      console.log(res);
+
+      if (res) {
+        const result = await fetchImageUrl(res);
+        console.log(result);
+      }
     }
   };
   const copylink = () => {

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -114,5 +114,16 @@ export const useLobbyPage = ({ roomId }: Props) => {
     }
   };
 
-  return { players, setImage, handleStart, isLoading };
+  const copylink = () => {
+    const path = window.location.origin;
+    const link = `${path}/top/${roomId}`;
+    navigator.clipboard.writeText(link);
+    toast({
+      title: '招待リンクをコピーしました。',
+      status: 'success',
+      isClosable: true,
+    });
+  };
+
+  return { players, setImage, handleStart, isLoading, copylink };
 };

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { uploadImage } from '@/libs/firebase/uploadImage';
 import { BASE_URL } from '@/utils/baseUrl';
 import { WS_URL } from '@/utils/baseUrl';
+import { FE_URL } from '@/utils/baseUrl';
 import { useToast } from '@chakra-ui/react';
 
 type Props = {
@@ -106,7 +107,7 @@ export const useLobbyPage = ({ roomId }: Props) => {
   };
 
   const copylink = () => {
-    const link = `${BASE_URL}/top/${roomId}`;
+    const link = `${FE_URL}/top/${roomId}`;
     navigator.clipboard.writeText(link);
     toast({
       title: '招待リンクをコピーしました。',

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -2,7 +2,7 @@ import { User } from '@/types/User';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import { uploadImage } from '@/libs/firebase/uploadImage';
-import { FE_URL } from '@/utils/baseUrl';
+import { BASE_URL, FE_URL } from '@/utils/baseUrl';
 import { useToast } from '@chakra-ui/react';
 import {
   onSnapshot,
@@ -14,6 +14,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/libs/firebase/firebase';
 import { fetchImageUrl } from '@/libs/firebase/fetchImageUrl';
+import axios from 'axios';
 
 type GameObjects = {
   Image: string;
@@ -33,7 +34,7 @@ export const useLobbyPage = ({ roomId }: Props) => {
   );
   const [image, setImage] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const id = 'TBOvYdRCOpVK3aW3qMLp';
+  const id = roomId;
 
   const userRef = collection(db, 'room', id, 'users');
   const gameObjectRef = collection(db, 'room', id, 'gameObjects');
@@ -100,7 +101,10 @@ export const useLobbyPage = ({ roomId }: Props) => {
 
       if (res) {
         const result = await fetchImageUrl(res);
-        console.log(result);
+        axios.post(`${BASE_URL}/api/v1/upload-image`, {
+          room_id: roomId,
+          url: result,
+        });
       }
     }
   };

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -25,7 +25,7 @@ type Props = {
   roomId: string;
 };
 
-export const useLobbyPage = ({ roomId }: Props) => {
+export const useLobbyPage = ({ roomId = 'RdjowLXkiimSmNoanCxy' }: Props) => {
   const router = useRouter();
   const toast = useToast();
   const [players, setPlayers] = useState<User[]>([]);
@@ -34,7 +34,7 @@ export const useLobbyPage = ({ roomId }: Props) => {
   );
   const [image, setImage] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const id = roomId;
+  const id = roomId !== '' ? roomId : 'RdjowLXkiimSmNoanCxy';
 
   const userRef = collection(db, 'room', id, 'users');
   const gameObjectRef = collection(db, 'room', id, 'gameObjects');

--- a/frontend/src/app/lobby/hooks/useLobbyPage.ts
+++ b/frontend/src/app/lobby/hooks/useLobbyPage.ts
@@ -24,11 +24,13 @@ export const useLobbyPage = ({ roomId }: Props) => {
   useEffect(() => {
     ws.onopen = () => {
       // 参加者の通知を検知してリストを更新する際のwsメッセージ
+      console.log('ws.onopen');
       ws.send('connect');
     };
 
     ws.onmessage = (event) => {
       const data = JSON.parse(event.data);
+      console.log('ws.onmessage', data);
 
       if (typeof data === 'string' && data === 'start') {
         router.replace('/ingame');
@@ -104,8 +106,7 @@ export const useLobbyPage = ({ roomId }: Props) => {
   };
 
   const copylink = () => {
-    const path = window.location.origin;
-    const link = `${path}/top/${roomId}`;
+    const link = `${BASE_URL}/top/${roomId}`;
     navigator.clipboard.writeText(link);
     toast({
       title: '招待リンクをコピーしました。',

--- a/frontend/src/app/lobby/page.tsx
+++ b/frontend/src/app/lobby/page.tsx
@@ -1,0 +1,5 @@
+import { LobbyPage } from '@/app/lobby/components/LobbyPage';
+
+export default function Lobby() {
+  return <LobbyPage />;
+}

--- a/frontend/src/app/top/components/hooks/useJoinRoomArea.ts
+++ b/frontend/src/app/top/components/hooks/useJoinRoomArea.ts
@@ -51,7 +51,7 @@ export const useJoinRoomArea = () => {
             avatarUrl: '',
           });
         });
-        router.replace('/');
+        router.replace('/lobby');
       })
       .catch(() =>
         toast({
@@ -89,7 +89,7 @@ export const useJoinRoomArea = () => {
             avatarUrl: '',
           });
         });
-        router.replace('/');
+        router.replace('/lobby');
       })
       .catch(() =>
         toast({

--- a/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
+++ b/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
@@ -10,6 +10,7 @@ type Props = {
   maxW?: string;
   height?: string;
   isDisabled: boolean;
+  isLoading?: boolean;
   onClick?: () => void;
 };
 
@@ -22,6 +23,7 @@ export function OutlineButtonWithRightIcon({
   maxW = '1000px',
   height,
   isDisabled,
+  isLoading,
   onClick,
 }: Props) {
   return (
@@ -38,6 +40,7 @@ export function OutlineButtonWithRightIcon({
       backgroundColor={bgColor}
       maxW={maxW}
       isDisabled={isDisabled}
+      isLoading={isLoading}
       onClick={onClick}
     >
       {text}

--- a/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
+++ b/frontend/src/components/Button/OutlineButtonWithRightIcon/index.tsx
@@ -8,6 +8,7 @@ type Props = {
   bgColor: string;
   borderWidth?: string;
   maxW?: string;
+  height?: string;
   isDisabled: boolean;
   onClick?: () => void;
 };
@@ -19,12 +20,14 @@ export function OutlineButtonWithRightIcon({
   bgColor,
   borderWidth = '3px',
   maxW = '1000px',
+  height,
   isDisabled,
   onClick,
 }: Props) {
   return (
     <Button
       w="full"
+      h={height}
       size="lg"
       rightIcon={rightIcon}
       color={color}

--- a/frontend/src/components/Input/Image/index.tsx
+++ b/frontend/src/components/Input/Image/index.tsx
@@ -25,6 +25,10 @@ export const InputImage = ({
   id,
   onChangeImage,
   label,
+  minH = 96,
+  minW = 96,
+  maxW = 96,
+  maxH = 96,
   ...props
 }: Props & ImageProps) => {
   const [isLoaded, setIsLoaded] = useState(!props.src);
@@ -40,10 +44,10 @@ export const InputImage = ({
           <Image
             w="full"
             h="full"
-            minH={80}
-            minW={80}
-            maxH={96}
-            maxW={96}
+            minH={minH}
+            minW={minW}
+            maxH={maxH}
+            maxW={maxW}
             alt={props.alt}
             onLoad={onLoad}
             onError={onLoad}
@@ -52,8 +56,8 @@ export const InputImage = ({
               <Center
                 w="full"
                 h="full"
-                minW={80}
-                minH={80}
+                minW={minW}
+                minH={minH}
                 bg="white"
                 p={10}
                 border={'1px solid'}

--- a/frontend/src/components/Input/Image/index.tsx
+++ b/frontend/src/components/Input/Image/index.tsx
@@ -19,6 +19,10 @@ type Props = {
   id: string;
   onChangeImage: ChangeEventHandler<HTMLInputElement>;
   label?: string;
+  minH?: number;
+  minW?: number;
+  maxH?: number;
+  maxW?: number;
 };
 
 export const InputImage = ({

--- a/frontend/src/components/Input/Image/index.tsx
+++ b/frontend/src/components/Input/Image/index.tsx
@@ -19,10 +19,6 @@ type Props = {
   id: string;
   onChangeImage: ChangeEventHandler<HTMLInputElement>;
   label?: string;
-  minH?: number;
-  minW?: number;
-  maxH?: number;
-  maxW?: number;
 };
 
 export const InputImage = ({

--- a/frontend/src/utils/baseUrl.ts
+++ b/frontend/src/utils/baseUrl.ts
@@ -1,9 +1,10 @@
-export const BASE_URL =
-  process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : 'https://tornado-team4-be.vercel.app';
+export const BASE_URL = 'https://tornado-team4-be.vercel.app';
+// process.env.NODE_ENV === 'development'
+//   ? 'http://localhost:8080'
+//   : 'https://tornado-team4-be.vercel.app';
 
-export const WS_URL =
-  process.env.NODE_ENV === 'development'
-    ? 'ws://localhost:8080'
-    : 'wss://tornado-team4-be.vercel.app';
+// export const WS_URL = 'ws://tornado-team4-be.vercel.app';
+export const WS_URL = 'ws://localhost:8080';
+// process.env.NODE_ENV === 'development'
+//   ? 'ws://localhost:8000'
+//   : 'wss://tornado-team4-be.vercel.app';

--- a/frontend/src/utils/baseUrl.ts
+++ b/frontend/src/utils/baseUrl.ts
@@ -1,10 +1,16 @@
-export const BASE_URL = 'https://tornado-team4-be.vercel.app';
+export const BASE_URL =
+  'https://tornado-team4-5ca017o7q-ltoppyl-team-dev.vercel.app';
 // process.env.NODE_ENV === 'development'
 //   ? 'http://localhost:8080'
 //   : 'https://tornado-team4-be.vercel.app';
 
-// export const WS_URL = 'ws://tornado-team4-be.vercel.app';
-export const WS_URL = 'ws://localhost:8080';
+export const WS_URL =
+  'ws://tornado-team4-5ca017o7q-ltoppyl-team-dev.vercel.app';
 // process.env.NODE_ENV === 'development'
 //   ? 'ws://localhost:8000'
 //   : 'wss://tornado-team4-be.vercel.app';
+
+export const FE_URL =
+  process.env.NODE_ENV === 'development'
+    ? 'http://localhost:3000'
+    : 'https://tornado-team4.vercel.app';

--- a/frontend/src/utils/baseUrl.ts
+++ b/frontend/src/utils/baseUrl.ts
@@ -1,14 +1,7 @@
 export const BASE_URL =
-  'https://tornado-team4-5ca017o7q-ltoppyl-team-dev.vercel.app';
-// process.env.NODE_ENV === 'development'
-//   ? 'http://localhost:8080'
-//   : 'https://tornado-team4-be.vercel.app';
-
-export const WS_URL =
-  'ws://tornado-team4-5ca017o7q-ltoppyl-team-dev.vercel.app';
-// process.env.NODE_ENV === 'development'
-//   ? 'ws://localhost:8000'
-//   : 'wss://tornado-team4-be.vercel.app';
+  process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://tornado-team4-be.vercel.app';
 
 export const FE_URL =
   process.env.NODE_ENV === 'development'

--- a/frontend/src/utils/baseUrl.ts
+++ b/frontend/src/utils/baseUrl.ts
@@ -1,4 +1,9 @@
-export const BASE_URL = 'https://tornado-team4-be.vercel.app';
-// process.env.NODE_ENV === 'development'
-//   ? 'http://localhost:8080'
-//   : 'https://tornado-team4-be.vercel.app';
+export const BASE_URL =
+  process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : 'https://tornado-team4-be.vercel.app';
+
+export const WS_URL =
+  process.env.NODE_ENV === 'development'
+    ? 'ws://localhost:8080'
+    : 'wss://tornado-team4-be.vercel.app';

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6384,6 +6384,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
+encoding@^0.1.13:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -7778,6 +7785,13 @@ iconv-lite@0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
@@ -10264,7 +10278,7 @@ safe-regex-test@^1.0.0:
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==


### PR DESCRIPTION
## 🔨 変更内容

- ロビー画面の作成
- 招待ボタンで招待リンクをコピーする
- 画像のアップロードができ、パズルをスタートできる
- プレイヤーの参加でプレイヤーリストが更新される

## このPRでやっていないこと
- ホストユーザーの確認
- roomIdのグローバルstate管理

## 📸 スクリーンショット
- リストの情報がないver
<img width="600" alt="スクリーンショット 2023-08-31 2 02 27" src="https://github.com/tornado-team4/tornado/assets/64648525/e1e226b2-6afa-4204-b8ef-93056b05d5eb">

- プレイヤーが参加でリストが更新されることを確認。
- 画像のアップロードでDBにデータが入ることを確認。
<img width="800" alt="スクリーンショット 2023-08-31 6 02 36" src="https://github.com/tornado-team4/tornado/assets/64648525/83baca69-c92b-4a7d-b046-86ead8d95de2">

## ✅ 解決するイシュー

- close #64

## 🤝 関連するイシュー

- #18 
