### PR TITLE
[FE] アイコンのクレジットの追加 + 他諸々変更

### DIFF
--- a/frontend/src/app/ingame/components/layouts/ClientComponent.tsx
+++ b/frontend/src/app/ingame/components/layouts/ClientComponent.tsx
@@ -41,7 +41,7 @@ export function ClientComponent() {
       listener();
       pictureListener();
     };
-
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/frontend/src/app/ingame/components/layouts/InputMemoryContainer.tsx
+++ b/frontend/src/app/ingame/components/layouts/InputMemoryContainer.tsx
@@ -9,7 +9,7 @@ import {
   InputGroup,
   InputLeftElement,
 } from '@chakra-ui/react';
-import React from 'react';
+import React, { useState } from 'react';
 
 type Props = {
   isDisabled?: boolean;
@@ -22,6 +22,8 @@ export function InputMemoryContainer({
   inputRef,
   onClick,
 }: Props) {
+  const [input, setInput] = useState('');
+
   return (
     <Center height={100} bgColor="#78CDFD">
       <Flex gap={5}>
@@ -34,6 +36,7 @@ export function InputMemoryContainer({
             placeholder="この写真へ思い出の一言"
             maxLength={20}
             ref={inputRef}
+            onChange={(e) => setInput(e.target.value)}
             isDisabled={isDisabled}
           />
         </InputGroup>
@@ -41,7 +44,7 @@ export function InputMemoryContainer({
         <Button
           rightIcon={<EmailIcon />}
           onClick={onClick}
-          isDisabled={isDisabled}
+          isDisabled={isDisabled || input === ''}
         >
           送る
         </Button>

--- a/frontend/src/app/lobby/components/PlayerList/index.tsx
+++ b/frontend/src/app/lobby/components/PlayerList/index.tsx
@@ -34,7 +34,7 @@ export const PlayerList = ({ list }: Props) => {
         >
           プレイヤー {playerNum}/6
         </Text>
-        <Box w="full" h="lg" overflow="scroll">
+        <Box w="full" h="lg" overflowY="scroll">
           <VStack spacing={3} w="full">
             {list.length > 0 ? (
               list.map((user) => (

--- a/frontend/src/app/top/components/JoinRoomArea/index.tsx
+++ b/frontend/src/app/top/components/JoinRoomArea/index.tsx
@@ -1,11 +1,26 @@
 'use client';
 
-import { Box, Text, VStack } from '@chakra-ui/react';
+import {
+  Box,
+  Center,
+  HStack,
+  Icon,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  Text,
+  VStack,
+  useDisclosure,
+} from '@chakra-ui/react';
 import { BiSolidRightArrow } from 'react-icons/bi';
 import { Avatar } from '@/app/top/components/Avatar';
 import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWithRightIcon';
 import { InputName } from '@/components/Input/Name';
 import { useJoinRoomArea } from '../hooks/useJoinRoomArea';
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import { VSpacer } from '@/components/Spacer';
 
 type Props = {
   roomId: string;
@@ -21,6 +36,10 @@ export function JoinRoomArea({ roomId }: Props) {
     setAvatar,
     avatarList,
   } = useJoinRoomArea();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const url =
+    'https://jp.freepik.com/free-vector/flat-lovely-animal-avatar-collection_845660.htm#query=アバター動物&position=2&from_view=keyword&track=ais';
 
   const handleJoinRoom = async () => {
     if (roomId === '') {
@@ -38,11 +57,19 @@ export function JoinRoomArea({ roomId }: Props) {
         <Text color="white" fontSize="2xl" fontWeight="bold">
           自分のアバターを設定してください
         </Text>
-        <Avatar
-          avatarList={avatarList}
-          avatarUrl={avatar}
-          setAvatarUrl={setAvatar}
-        />
+        <HStack alignItems="flex-end">
+          <Avatar
+            avatarList={avatarList}
+            avatarUrl={avatar}
+            setAvatarUrl={setAvatar}
+          />
+          <Icon
+            as={InfoOutlineIcon}
+            boxSize={6}
+            _hover={{ cursor: 'pointer' }}
+            onClick={onOpen}
+          />
+        </HStack>
         <InputName
           borderColor="#56C1FC"
           value={name}
@@ -59,6 +86,27 @@ export function JoinRoomArea({ roomId }: Props) {
           />
         </Box>
       </VStack>
+
+      {/* アイコンの著作権に関するモーダル */}
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalBody>
+            <Center>
+              <HStack>
+                <VSpacer size={12} />
+                <Text>アバターアイコンの著作権：</Text>
+                <Text>Freepik</Text>
+                {/* FIXME: なぜか遷移すると 403 が返ってくる, リンク先の問題のような気が… */}
+                <Link href={url} isExternal>
+                  Freepik
+                </Link>
+                <VSpacer size={12} />
+              </HStack>
+            </Center>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </Box>
   );
 }

--- a/frontend/src/app/top/components/JoinRoomArea/index.tsx
+++ b/frontend/src/app/top/components/JoinRoomArea/index.tsx
@@ -96,8 +96,7 @@ export function JoinRoomArea({ roomId }: Props) {
               <HStack>
                 <VSpacer size={12} />
                 <Text>アバターアイコンの著作権：</Text>
-                <Text>Freepik</Text>
-                {/* FIXME: なぜか遷移すると 403 が返ってくる, リンク先の問題のような気が… */}
+                {/* NOTE: ローカルだと 403 が返ってくるが、デプロイ環境では正常に動く */}
                 <Link href={url} isExternal>
                   Freepik
                 </Link>


### PR DESCRIPTION
## 🔨 変更内容

- アイコンのクレジットの記載
- 参加者リストの横スクロールのバーの削除
- ピースを配るためのコメントが空の時に送信できないようにした

## 📸 スクリーンショット
![image](https://github.com/tornado-team4/tornado/assets/68209431/4796bc7e-b091-4ae7-9e2f-7089ae4559b4)


## ✅ 解決するイシュー

- close #67

## 🤝 関連するイシュー

- #0
