### PR TITLE
[FE] モバイルからアクセスした場合に、対応していない旨を表示する

### DIFF
--- a/frontend/src/app/top/components/Mobile/index.stories.tsx
+++ b/frontend/src/app/top/components/Mobile/index.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Mobile } from './index';
+
+const meta: Meta<typeof Mobile> = {
+  title: 'TopPage/Mobile',
+  component: Mobile,
+};
+
+export default meta;
+type Story = StoryObj<typeof Mobile>;
+
+export const Default: Story = {
+  args: {
+    bgColor: 'blue',
+  },
+};

--- a/frontend/src/app/top/components/Mobile/index.tsx
+++ b/frontend/src/app/top/components/Mobile/index.tsx
@@ -1,0 +1,26 @@
+import { Box, Center, Text } from '@chakra-ui/react';
+import React from 'react';
+import bg_img from '/public/bg_img.jpeg';
+
+export const Mobile = () => {
+  return (
+    <>
+      <Box h="100vh" bgImage={bg_img.src} objectFit="cover" p={8}>
+        <Center
+          w="full"
+          h="full"
+          bg="whiteAlpha.500"
+          borderRadius={10}
+          py={10}
+          px={4}
+        >
+          <Text whiteSpace="pre-line">
+            {'青春パズルをご利用いただきありがとうございます。\n' +
+              '現在弊サービスはPC版ブラウザからのみご利用いただけます。\n' +
+              'モバイル版ブラウザへの対応も順次行っていく予定です。'}
+          </Text>
+        </Center>
+      </Box>
+    </>
+  );
+};

--- a/frontend/src/app/top/page.tsx
+++ b/frontend/src/app/top/page.tsx
@@ -1,7 +1,10 @@
 'use client';
-
+import { useBreakpointValue } from '@chakra-ui/react';
 import { TopPage } from './components/TopPage';
+import { Mobile } from '@/app/top/components/Mobile';
 
 export default function Top() {
-  return <TopPage roomId="" />;
+  const mediaType = useBreakpointValue({ base: 'phone', md: 'pc' });
+
+  return mediaType === 'pc' ? <TopPage roomId="" /> : <Mobile />;
 }


### PR DESCRIPTION
## 🔨 変更内容

- モバイルからアクセスした場合に、対応していない旨を表示する

## 📸 スクリーンショット
![image](https://github.com/tornado-team4/tornado/assets/68209431/5968213f-1be3-4a6d-9a7a-a2561c3ee7e2)


## ✅ 解決するイシュー

- close #99

## 🤝 関連するイシュー

- #0
