### PR TITLE
[FE] 完成画面の画像のリサイズ

### DIFF
--- a/frontend/src/app/complete/components/CompletePage/index.stories.tsx
+++ b/frontend/src/app/complete/components/CompletePage/index.stories.tsx
@@ -54,16 +54,30 @@ const commentList = [
   },
 ];
 
-export const ImageSizePartern1: Story = {
+export const ImageSizePattern1: Story = {
   args: {
     commentList: commentList,
     imageUrl: 'https://placehold.jp/272343/ffd803/640x400.png',
   },
 };
 
-export const ImageSizePartern2: Story = {
+export const ImageSizePattern2: Story = {
   args: {
     commentList: commentList,
     imageUrl: 'https://tools.arashichang.com/hd1080',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    commentList: commentList,
+    imageUrl: 'https://tools.arashichang.com/300x200/cccccc/ffffff',
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    commentList: commentList,
+    imageUrl: 'https://tools.arashichang.com/wideskyscraper',
   },
 };

--- a/frontend/src/app/complete/components/CompletePage/index.tsx
+++ b/frontend/src/app/complete/components/CompletePage/index.tsx
@@ -1,6 +1,5 @@
 'use client';
-
-import { Box, HStack, Image } from '@chakra-ui/react';
+import { Box, HStack, Image as ChakraImage } from '@chakra-ui/react';
 import bg_img from '/public/bg_img.jpeg';
 import { Comment } from '@/types/Comment';
 import { CommentList } from '@/app/complete/components/CommentList';
@@ -8,6 +7,7 @@ import { OutlineButtonWithRightIcon } from '@/components/Button/OutlineButtonWit
 import { BsHouse } from 'react-icons/bs';
 // import { BiSolidRightArrow } from 'react-icons/bi';
 import { /*  HSpacer, */ VSpacer } from '@/components/Spacer';
+import { useEffect, useState } from 'react';
 
 type Props = {
   imageUrl: string;
@@ -23,6 +23,44 @@ export const CompletePage = ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onClickEdit,
 }: Props) => {
+  const [imageSize, setImageSize] = useState({
+    width: '500px',
+    height: '500px',
+  });
+
+  const img = new Image();
+  img.src = imageUrl;
+
+  useEffect(() => {
+    img.onload = () => {
+      const tempWidth = img.width;
+      const tempHeight = img.height;
+      const ratio =
+        tempWidth < tempHeight
+          ? tempWidth / tempHeight
+          : tempHeight / tempWidth;
+
+      if (tempWidth < tempHeight) {
+        const newHeight = 600 < tempHeight ? 600 : tempHeight;
+        const newWidth = Math.round(newHeight * ratio);
+        setImageSize({
+          width: `${newWidth}px`,
+          height: `${newHeight}px`,
+        });
+      } else {
+        const newWidth = 600 < tempWidth ? 600 : tempWidth;
+        const newHeight = Math.round(newWidth * ratio);
+        setImageSize({
+          width: `${newWidth}px`,
+          height: `${newHeight}px`,
+        });
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  console.log('imageSize', imageSize);
+
   return (
     <Box
       w="full"
@@ -35,7 +73,13 @@ export const CompletePage = ({
       {/* NOTE: 100vh とするとスクロールバーが出てしまうため微調整 */}
       <HStack minH="90vh">
         <Box h="100%" w="50%">
-          <Image margin="auto" src={imageUrl} alt="Complete Puzzle" />
+          <ChakraImage
+            h={imageSize.height}
+            w={imageSize.width}
+            margin="auto"
+            src={imageUrl}
+            alt="Complete Puzzle"
+          />
           <VSpacer size={12} />
           <HStack justifyContent="center">
             <OutlineButtonWithRightIcon


### PR DESCRIPTION
## 🔨 変更内容

- 完成画面の画像のリサイズ

## 📸 スクリーンショット
### storybook にあるパターンで正常に動いていることを確認
一例
![image](https://github.com/tornado-team4/tornado/assets/68209431/8cdd8b7b-6336-435c-8605-fccbe5019da2)


## ✅ 解決するイシュー

- close #95

## 🤝 関連するイシュー

- #0
